### PR TITLE
Add Markov Chain implementation to generate text

### DIFF
--- a/test/nl/surf/markov_chain_test.clj
+++ b/test/nl/surf/markov_chain_test.clj
@@ -7,7 +7,7 @@
 
 (deftest generate
   (let [gen (fn [text & opts]
-              (sut/generate (apply sut/build-state-space text opts)))]
+              (sut/generate (apply sut/analyse text opts)))]
     (testing "some examples"
       (is (every? #{[1 2 3]}
                   (repeatedly sample-size
@@ -32,7 +32,7 @@
 
 (deftest generate-text
   (let [gen (fn [text & opts]
-              (sut/generate-text (apply sut/build-text-state-space text opts)))]
+              (sut/generate-text (apply sut/analyse-text text opts)))]
     (testing "some examples"
       (is (every? #{"Fred kisses Wilma."}
                   (repeatedly sample-size


### PR DESCRIPTION
Give it a try:
```
(def ss (-> "https://gist.github.com/remvee/df6c9740495ef3ed11eb7f9f2f2f07ae/raw/93d73cebde379565efaa55c698c24323b813593d/Het-Boek.text-only.txt"
            java.net.URL.
            slurp
            build-text-state-space))
(println (clojure.string/join "\n" (repeatedly 10 #(generate-text ss))))
```